### PR TITLE
Update Maven compiler plugin to version 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,10 +172,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Removed the explicit source and target version tags as well.