### PR TITLE
Oauth login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-mapper-orm</artifactId>
             <version>7.2.2.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,39 @@ TODO: Proxy is "configured" in FE\package.json, this is to help with communicati
 
 ###
 ![image](https://github.com/user-attachments/assets/53d1807f-fdeb-4541-87a8-eb7089aa216a)
+
+---
+
+## GitHub OAuth2
+### 1. Get client ID and client secret (Use this [link](https://github.com/settings/developers) to create an OAuth app to use locally)
+1. Set the Homepage URL to http://localhost:8080
+2. Set the Authorization callback URL to http://localhost:8080/login/oauth2/code/github
+3. Register the application
+4. Generate client secret
+### 2. Add client ID and client secret to your application:
+
+***Option 1:***  
+IntelliJ navbar -> Run -> Edit configurations -> Environment variables
+
+***Option 2:***  
+Create a .env file in the root of the project
+### Add:
+```
+GITHUB_CLIENT_ID=id (replace id with your client ID)
+GITHUB_CLIENT_SECRET=secret (replace secret with your client secret)
+```
+
+### 3. Run the application
+
+### Endpoints:
+```
+http://localhost:8080/
+http://localhost:8080/login
+http://localhost:8080/logout
+```
+---  
+### Switch between profiles in ***application.properties***:
+```
+spring.profiles.active=production  
+spring.profiles.active=development
+```

--- a/src/main/java/org/fungover/system2024/config/SecurityConfig.java
+++ b/src/main/java/org/fungover/system2024/config/SecurityConfig.java
@@ -1,16 +1,27 @@
 package org.fungover.system2024.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final String baseUrl;
+
+    public SecurityConfig(@Value("${app.baseUrl}") String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
 
     @Bean
     @Profile("development")
@@ -21,18 +32,6 @@ public class SecurityConfig {
                         .anyRequest().permitAll() // Allow all requests for development
                 )
                 .httpBasic(Customizer.withDefaults()); // Use HTTP Basic authentication for development
-
-        // TODO: Add specific endpoint security rules here
-        // Example:
-        // .authorizeHttpRequests(auth -> auth
-        //         .requestMatchers("/public/**").permitAll() // Public endpoints
-        //         .anyRequest().authenticated() // All other endpoints require authentication
-        // )
-
-        // TODO: Configure OAuth2 login with GitHub here
-        // Example:
-        // .oauth2Login(Customizer.withDefaults()); // OAuth2 login configuration for future use
-
         return http.build();
     }
 
@@ -44,19 +43,24 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().authenticated() // Require authentication for all requests
                 )
-                .httpBasic(Customizer.withDefaults()); // Use HTTP Basic authentication
-
-        // TODO: Add specific endpoint security rules here
-        // Example:
-        // .authorizeHttpRequests(auth -> auth
-        //         .requestMatchers("/public/**").permitAll() // Public endpoints
-        //         .anyRequest().authenticated() // All other endpoints require authentication
-        // )
-
-        // TODO: Configure OAuth2 login with GitHub here
-        // Example:
-        // .oauth2Login(Customizer.withDefaults()); // OAuth2 login configuration for future use
-
+                .oauth2Login(Customizer.withDefaults())
+                .logout((logout) -> logout
+                        .logoutUrl("/logout")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .deleteCookies("JSESSIONID")
+                        .logoutSuccessHandler(logoutSuccessHandler())
+                )
+                .exceptionHandling((exceptions) -> exceptions
+                        .defaultAuthenticationEntryPointFor(
+                                new LoginUrlAuthenticationEntryPoint("/oauth2/authorization/github"),
+                                new MediaTypeRequestMatcher(MediaType.TEXT_HTML)
+                        ));
         return http.build();
+    }
+
+    private LogoutSuccessHandler logoutSuccessHandler() {
+        return ((request, response, authentication) ->
+                response.sendRedirect(baseUrl + "/login"));
     }
 }

--- a/src/main/java/org/fungover/system2024/controller/LoginController.java
+++ b/src/main/java/org/fungover/system2024/controller/LoginController.java
@@ -1,0 +1,21 @@
+package org.fungover.system2024.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/")
+    public String index(@AuthenticationPrincipal OAuth2User principal, Model model) {
+        if (principal != null) {
+            model.addAttribute("name", principal.getAttribute("name"));
+        } else {
+            model.addAttribute("name", "Guest");
+        }
+        return "index";
+    }
+}

--- a/src/main/java/org/fungover/system2024/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/fungover/system2024/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.fungover.system2024.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ProblemDetail handleException(Exception ex) {
+        ProblemDetail problemDetails = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getLocalizedMessage());
+        problemDetails.setType(URI.create("http://localhost:8080/errors/general-error"));
+        problemDetails.setTitle("General Error");
+        return problemDetails;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,13 @@ spring.jpa.properties.hibernate.search.backend.analysis.configurer = org.fungove
 spring.jpa.properties.hibernate.search.backend.directory.type = local-filesystem
 spring.jpa.properties.hibernate.search.backend.directory.root=${LUCENE_INDEXES:lucene_indexes}
 
+spring.config.import=optional:file:./.env[.properties],optional:file:.env[.properties]
+spring.security.oauth2.client.registration.github.clientId=${GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.clientSecret=${GITHUB_CLIENT_SECRET}
+spring.security.oauth2.client.registration.github.redirect-uri={baseUrl}/login/oauth2/code/github
+spring.security.oauth2.client.registration.github.scope=read:user,user:email
+spring.security.oauth2.client.provider.github.authorization-uri=https://github.com/login/oauth/authorize
+spring.security.oauth2.client.provider.github.token-uri=https://github.com/login/oauth/access_token
+spring.security.oauth2.client.provider.github.user-info-uri=https://api.github.com/user
+spring.security.oauth2.client.provider.github.user-name-attribute=id
+app.baseUrl=http://localhost:8080

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title>GitHub OAuth2 Login</title>
+</head>
+<body>
+<h1>Welcome, <span th:text="${name}"></span>!</h1>
+<a href="/logout">Logout</a>
+</body>
+</html>>

--- a/src/test/java/org/fungover/system2024/controller/LoginControllerTest.java
+++ b/src/test/java/org/fungover/system2024/controller/LoginControllerTest.java
@@ -1,0 +1,68 @@
+package org.fungover.system2024.controller;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(LoginController.class)
+class LoginControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @Mock
+    private OAuth2User oAuth2User;
+    private AutoCloseable mocks;
+
+    @BeforeEach
+    void setUp() {
+        try {
+            mocks = MockitoAnnotations.openMocks(this);
+            mvc = MockMvcBuilders.webAppContextSetup(context)
+                    .apply(SecurityMockMvcConfigurers.springSecurity())
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (mocks != null) {
+            mocks.close();
+        }
+    }
+
+    @Test
+    void index() throws Exception {
+        Map<String, Object> attributes = Collections.singletonMap("name", "Test User");
+        when(oAuth2User.getAttributes()).thenReturn(attributes);
+        when(oAuth2User.getAttribute("name")).thenReturn("Test User");
+        when(oAuth2User.getName()).thenReturn("Test User");
+
+        mvc.perform(get("/").with(oauth2Login().oauth2User(oAuth2User)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"))
+                .andExpect(model().attribute("name", "Test User"));
+    }
+}


### PR DESCRIPTION
New branch, same issue -  Configure GitHub OAuth for Social Login #2 

I have not changed endpoints to start with "/api" as were suggested in my earlier PR, because of problems with OAuth2's flow. But I can make a separate issue about it.

---

## GitHub OAuth2
### 1. Get client ID and client secret (Use this [link](https://github.com/settings/developers) to create an OAuth app to use locally)
1. Set the Homepage URL to http://localhost:8080
2. Set the Authorization callback URL to http://localhost:8080/login/oauth2/code/github
3. Register the application
4. Generate client secret
### 2. Add client ID and client secret to your application:

***Option 1:***  
IntelliJ navbar -> Run -> Edit configurations -> Environment variables

***Option 2:***  
Create a .env file in the root of the project
### Add:
```
GITHUB_CLIENT_ID=id (replace id with your client ID)
GITHUB_CLIENT_SECRET=secret (replace secret with your client secret)
```

### 3. Run the application

### Endpoints:
```
http://localhost:8080/
http://localhost:8080/login
http://localhost:8080/logout
```
---  
### Switch between profiles in ***application.properties***:
```
spring.profiles.active=production  
spring.profiles.active=development
```