### PR TITLE
#48 Update GitHub Actions to Skip Tests for Frontend Changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,37 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '23'
           cache: maven
+
+      - name: Check for changes in Java source or test files (excluding frontend)
+        id: check_java_changes
+        run: |
+          git diff --exit-code --quiet -- src/main src/test || echo "Java source or test files have changed, running tests."
+
       - name: Compile with Maven
         run: mvn -B compile --file pom.xml
 
       - name: Test with Maven
+        if: steps.check_java_changes.outcome != 'success'
         run: mvn -B test --file pom.xml
+
+      - name: Skip tests if no Java or test files have changed
+        if: steps.check_java_changes.outcome == 'success'
+        run: echo "No Java or test files changed, skipping tests."

--- a/logs/app.log
+++ b/logs/app.log
@@ -1,0 +1,3 @@
+2024-12-12 09:56:44 [http-nio-8080-exec-7] INFO  o.f.s.controller.LoginController - User '123842543' logged in
+2024-12-12 09:57:47 [http-nio-8080-exec-1] INFO  o.f.s.controller.LoginController - User '123842543' logged in
+2024-12-12 09:58:12 [http-nio-8080-exec-10] INFO  o.f.s.controller.LoginController - User '123842543' logged in


### PR DESCRIPTION
Modified the GitHub Actions workflow to check for changes only in src/main and src/test directories before running tests.

If no changes are detected in these directories, tests are skipped.

Compilation still runs regardless of changes to ensure the application builds correctly.


Might need thorough review, I dont really now how to tests this, ideas are welcome.
Also it's my first time to do changes in GH-actions/ci.YML and the syntax was quite confusing at first.