### PR TITLE
100 initialize dev user to fake auth in development

### DIFF
--- a/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package org.fungover.system2024.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.fungover.system2024.user.entity.User;
+import org.fungover.system2024.user.repository.UserRepository;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Profile("development")
+public class DevelopmentAuthenticationFilter extends GenericFilterBean {
+
+    private final UserRepository userRepository;
+
+    public DevelopmentAuthenticationFilter(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        User user = userRepository.findByEmail("development@example.com")
+                .orElseThrow(() -> new RuntimeException("Development user not found by email"));
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", user.getEmail());
+
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER"));
+
+        OAuth2User oAuth2DevelopmentUser = new DefaultOAuth2User(
+                authorities, attributes, "email");
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                oAuth2DevelopmentUser, "N/A", authorities);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
@@ -5,63 +5,37 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import org.fungover.system2024.user.entity.User;
-import org.fungover.system2024.user.repository.UserRepository;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import static org.fungover.system2024.config.DevelopmentAuthenticationFilterService.createAuthentication;
 
 @Component
 @Profile("development")
 public class DevelopmentAuthenticationFilter extends GenericFilterBean {
+    private final DevelopmentAuthenticationFilterService developmentAuthenticationFilterService;
 
-    private final UserRepository userRepository;
-
-    public DevelopmentAuthenticationFilter(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public DevelopmentAuthenticationFilter(DevelopmentAuthenticationFilterService developmentAuthenticationFilterService) {
+        this.developmentAuthenticationFilterService = developmentAuthenticationFilterService;
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
-        User user = getUser();
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        try {
+            User user = developmentAuthenticationFilterService.getUser();
+            OAuth2User oAuth2DevelopmentUser = developmentAuthenticationFilterService.createOAuth2User(user);
+            Authentication authentication = createAuthentication(oAuth2DevelopmentUser);
 
-        OAuth2User oAuth2DevelopmentUser = createOAuth2User(user);
-
-        Authentication authentication = createAuthentication(oAuth2DevelopmentUser);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        chain.doFilter(request, response);
-    }
-
-    private User getUser() {
-        return userRepository.findByEmail("development@example.com")
-                .orElseThrow(() -> new RuntimeException("Development user not found by email"));
-    }
-
-    private DefaultOAuth2User createOAuth2User(User user) {
-        Map<String, Object> attributes = new HashMap<>();
-        attributes.put("email", user.getEmail());
-
-        List<SimpleGrantedAuthority> authorities = List.of(
-                new SimpleGrantedAuthority("ROLE_USER")
-        );
-
-        return new DefaultOAuth2User(authorities, attributes, "email");
-    }
-
-    private static Authentication createAuthentication(OAuth2User oAuth2DevelopmentUser) {
-        return new UsernamePasswordAuthenticationToken(
-                oAuth2DevelopmentUser, "N/A", oAuth2DevelopmentUser.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            chain.doFilter(request, response);
+        } catch (RuntimeException exception) {
+            throw new ServletException(exception);
+        }
     }
 }

--- a/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilter.java
@@ -32,23 +32,36 @@ public class DevelopmentAuthenticationFilter extends GenericFilterBean {
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        User user = userRepository.findByEmail("development@example.com")
-                .orElseThrow(() -> new RuntimeException("Development user not found by email"));
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        User user = getUser();
 
+        OAuth2User oAuth2DevelopmentUser = createOAuth2User(user);
+
+        Authentication authentication = createAuthentication(oAuth2DevelopmentUser);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        chain.doFilter(request, response);
+    }
+
+    private User getUser() {
+        return userRepository.findByEmail("development@example.com")
+                .orElseThrow(() -> new RuntimeException("Development user not found by email"));
+    }
+
+    private DefaultOAuth2User createOAuth2User(User user) {
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("email", user.getEmail());
 
         List<SimpleGrantedAuthority> authorities = List.of(
-                new SimpleGrantedAuthority("ROLE_USER"));
+                new SimpleGrantedAuthority("ROLE_USER")
+        );
 
-        OAuth2User oAuth2DevelopmentUser = new DefaultOAuth2User(
-                authorities, attributes, "email");
+        return new DefaultOAuth2User(authorities, attributes, "email");
+    }
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                oAuth2DevelopmentUser, "N/A", authorities);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        chain.doFilter(request, response);
+    private static Authentication createAuthentication(OAuth2User oAuth2DevelopmentUser) {
+        return new UsernamePasswordAuthenticationToken(
+                oAuth2DevelopmentUser, "N/A", oAuth2DevelopmentUser.getAuthorities());
     }
 }

--- a/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterService.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterService.java
@@ -1,0 +1,44 @@
+package org.fungover.system2024.config;
+
+import org.fungover.system2024.user.entity.User;
+import org.fungover.system2024.user.repository.UserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class DevelopmentAuthenticationFilterService {
+    private final UserRepository userRepository;
+
+    public DevelopmentAuthenticationFilterService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User getUser() {
+        return userRepository.findByEmail("development@example.com")
+                .orElseThrow(() -> new RuntimeException("Development user not found by email"));
+    }
+
+    public DefaultOAuth2User createOAuth2User(User user) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", user.getEmail());
+
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER")
+        );
+
+        return new DefaultOAuth2User(authorities, attributes, "email");
+    }
+
+    public static Authentication createAuthentication(OAuth2User oAuth2DevelopmentUser) {
+        return new UsernamePasswordAuthenticationToken(
+                oAuth2DevelopmentUser, "N/A", oAuth2DevelopmentUser.getAuthorities());
+    }
+}

--- a/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterService.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterService.java
@@ -22,7 +22,7 @@ public class DevelopmentAuthenticationFilterService {
     }
 
     public User getUser() {
-        return userRepository.findByEmail("development@example.com")
+        return userRepository.findByEmail("Code653ht57t26234yp@example.com")
                 .orElseThrow(() -> new RuntimeException("Development user not found by email"));
     }
 

--- a/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
@@ -1,0 +1,30 @@
+package org.fungover.system2024.config;
+
+import org.fungover.system2024.user.entity.User;
+import org.fungover.system2024.user.repository.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@Profile("development")
+public class DevelopmentUserInitialize {
+
+    @Bean
+    public CommandLineRunner initializeDevelopmentUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        return args -> {
+            String email = "development@example.com";
+
+            if (userRepository.findByEmail(email).isEmpty()) {
+                User user = new User();
+                user.setFirst_name("Junior");
+                user.setLast_name("Developer");
+                user.setEmail(email);
+                user.setPassword(passwordEncoder.encode("password"));
+                userRepository.save(user);
+            }
+        };
+    }
+}

--- a/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
@@ -2,6 +2,7 @@ package org.fungover.system2024.config;
 
 import org.fungover.system2024.user.entity.User;
 import org.fungover.system2024.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration
 @Profile("development")
 public class DevelopmentUserInitialize {
+
+    @Value("${development.user.password}")
+    private String password;
 
     @Bean
     public CommandLineRunner initializeDevelopmentUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
@@ -22,7 +26,7 @@ public class DevelopmentUserInitialize {
                 user.setFirst_name("Junior");
                 user.setLast_name("Code653ht57t26234yp");
                 user.setEmail(email);
-                user.setPassword(passwordEncoder.encode("password"));
+                user.setPassword(passwordEncoder.encode(password));
                 userRepository.save(user);
             }
         };

--- a/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
+++ b/src/main/java/org/fungover/system2024/config/DevelopmentUserInitialize.java
@@ -15,12 +15,12 @@ public class DevelopmentUserInitialize {
     @Bean
     public CommandLineRunner initializeDevelopmentUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
         return args -> {
-            String email = "development@example.com";
+            String email = "Code653ht57t26234yp@example.com";
 
             if (userRepository.findByEmail(email).isEmpty()) {
                 User user = new User();
                 user.setFirst_name("Junior");
-                user.setLast_name("Developer");
+                user.setLast_name("Code653ht57t26234yp");
                 user.setEmail(email);
                 user.setPassword(passwordEncoder.encode("password"));
                 userRepository.save(user);

--- a/src/main/java/org/fungover/system2024/config/SecurityConfig.java
+++ b/src/main/java/org/fungover/system2024/config/SecurityConfig.java
@@ -7,13 +7,27 @@ import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final DevelopmentAuthenticationFilter developmentAuthenticationFilter;
+
+    public SecurityConfig(DevelopmentAuthenticationFilter developmentAuthenticationFilter) {
+        this.developmentAuthenticationFilter = developmentAuthenticationFilter;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     @Profile("development")
@@ -23,6 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll() // Allow all requests for development
                 )
+                .addFilterBefore(developmentAuthenticationFilter, BasicAuthenticationFilter.class)
                 .httpBasic(Customizer.withDefaults()); // Use HTTP Basic authentication for development
         return http.build();
     }

--- a/src/main/java/org/fungover/system2024/user/repository/UserRepository.java
+++ b/src/main/java/org/fungover/system2024/user/repository/UserRepository.java
@@ -1,7 +1,12 @@
 package org.fungover.system2024.user.repository;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import org.fungover.system2024.user.entity.User;
 import org.springframework.data.repository.ListCrudRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends ListCrudRepository<User, Integer> {
+    Optional<User> findByEmail(@NotBlank @Email String email);
 }

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,0 +1,1 @@
+development.user.password=password

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -1,5 +1,6 @@
 type Query {
     users: [User]
+    testUserAuth: String
 }
 
 type User {

--- a/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterServiceTest.java
+++ b/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterServiceTest.java
@@ -1,0 +1,105 @@
+package org.fungover.system2024.config;
+
+import org.fungover.system2024.user.entity.User;
+import org.fungover.system2024.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DevelopmentAuthenticationFilterServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    private DevelopmentAuthenticationFilterService developmentAuthenticationFilterService;
+
+    @BeforeEach
+    void setUp() {
+        developmentAuthenticationFilterService = new DevelopmentAuthenticationFilterService(userRepository);
+    }
+
+    @Test
+    void testGetUser() {
+        User user = new User();
+        user.setEmail("development@example.com");
+
+        when(userRepository.findByEmail("development@example.com"))
+                .thenReturn(Optional.of(user));
+
+        User validUser = developmentAuthenticationFilterService.getUser();
+
+        assertNotNull(validUser);
+        assertEquals("development@example.com", validUser.getEmail());
+    }
+
+    @Test
+    void testGetUserNotFound() {
+        when(userRepository.findByEmail("development@example.com"))
+                .thenReturn(Optional.empty());
+
+        RuntimeException runtimeException = assertThrows(RuntimeException.class, ()
+                -> developmentAuthenticationFilterService.getUser());
+
+        assertEquals("Development user not found by email", runtimeException.getMessage());
+    }
+
+    @Test
+    void testCreateOAut2User() {
+        User user = new User();
+        user.setEmail("development@example.com");
+
+        DefaultOAuth2User oAuth2User = developmentAuthenticationFilterService.createOAuth2User(user);
+        List<String> authorities = oAuth2User.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        assertNotNull(oAuth2User);
+        assertEquals("development@example.com", oAuth2User.getAttributes().get("email"));
+        assertTrue(authorities.contains("ROLE_USER"));
+    }
+
+    @Test
+    void testCreateAuthentication() {
+        Map<String, Object> attributes = Map.of("email", "development@example.com");
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+        OAuth2User oAuth2User = new DefaultOAuth2User(authorities, attributes, "email");
+
+        Authentication authentication = DevelopmentAuthenticationFilterService.createAuthentication(oAuth2User);
+
+        assertNotNull(authentication);
+        assertEquals(authorities, authentication.getAuthorities());
+        assertEquals(oAuth2User, authentication.getPrincipal());
+        assertEquals("development@example.com", authentication.getName());
+        assertEquals("N/A", authentication.getCredentials().toString());
+        assertInstanceOf(UsernamePasswordAuthenticationToken.class, authentication);
+    }
+
+    @Test
+    void testCreateAuthenticationNoAuthorities() {
+        Map<String, Object> attributes = Map.of("email", "development@example.com");
+        List<GrantedAuthority> authorities = Collections.emptyList();
+        OAuth2User oAuth2User = new DefaultOAuth2User(authorities, attributes, "email");
+
+        Authentication authentication = DevelopmentAuthenticationFilterService.createAuthentication(oAuth2User);
+
+        assertNotNull(authentication);
+        assertEquals(oAuth2User, authentication.getPrincipal());
+        assertTrue(authentication.getAuthorities().isEmpty());
+    }
+}

--- a/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterSpringBootTest.java
+++ b/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterSpringBootTest.java
@@ -1,0 +1,58 @@
+package org.fungover.system2024.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.MySQLContainer;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.springframework.http.MediaType;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("development")
+class DevelopmentAuthenticationFilterSpringBootTest {
+    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:9.1")
+            .withDatabaseName("system24dbtest")
+            .withUsername("myuser")
+            .withPassword("secret");
+
+    static {
+        mysqlContainer.start();
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry propertyRegistry) {
+        propertyRegistry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        propertyRegistry.add("spring.datasource.username", mysqlContainer::getUsername);
+        propertyRegistry.add("spring.datasource.password", mysqlContainer::getPassword);
+        propertyRegistry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void testDevelopmentAuthenticationFilter() throws Exception {
+        String request = "{\"query\": \"{testUserAuth}\"}";
+
+        MvcResult result = mockMvc.perform(post("/graphql").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertTrue(result.getResponse().getContentAsString().contains("Code653ht57t26234yp@example.com"));
+    }
+}

--- a/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterTest.java
+++ b/src/test/java/org/fungover/system2024/config/DevelopmentAuthenticationFilterTest.java
@@ -1,0 +1,88 @@
+package org.fungover.system2024.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.fungover.system2024.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DevelopmentAuthenticationFilterTest {
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private DevelopmentAuthenticationFilterService developmentAuthenticationFilterService;
+
+    private DevelopmentAuthenticationFilter filter;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setEmail("development@example.com");
+
+        filter = new DevelopmentAuthenticationFilter(developmentAuthenticationFilterService);
+    }
+
+    @Test
+    void testDoFilter() throws ServletException, IOException {
+        DevelopmentAuthenticationFilterService service = new DevelopmentAuthenticationFilterService(null);
+        DefaultOAuth2User oAuth2User = service.createOAuth2User(user);
+
+        when(developmentAuthenticationFilterService.getUser()).thenReturn(user);
+        when(developmentAuthenticationFilterService.createOAuth2User(user)).thenReturn(oAuth2User);
+
+        SecurityContextHolder.clearContext();
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        assertNotNull(authentication);
+        assertTrue(authentication.isAuthenticated());
+        assertInstanceOf(UsernamePasswordAuthenticationToken.class, authentication);
+        assertEquals("development@example.com", ((OAuth2User) authentication.getPrincipal()).getAttribute("email"));
+
+        verify(developmentAuthenticationFilterService).getUser();
+        verify(developmentAuthenticationFilterService).createOAuth2User(user);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void testDoFilterWithException() throws ServletException, IOException {
+        when(developmentAuthenticationFilterService.getUser())
+                .thenThrow(new RuntimeException("Development user not found by email"));
+
+        SecurityContextHolder.clearContext();
+
+        ServletException servletException = assertThrows(ServletException.class, () ->
+                filter.doFilter(request, response, chain));
+
+        assertEquals("Development user not found by email", servletException.getCause().getMessage());
+        assertInstanceOf(RuntimeException.class, servletException.getCause());
+
+        verify(chain, never()).doFilter(request, response);
+    }
+}

--- a/src/test/java/org/fungover/system2024/config/DevelopmentUserInitializeSpringBootTest.java
+++ b/src/test/java/org/fungover/system2024/config/DevelopmentUserInitializeSpringBootTest.java
@@ -1,0 +1,49 @@
+package org.fungover.system2024.config;
+
+import org.fungover.system2024.user.entity.User;
+import org.fungover.system2024.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("development")
+class DevelopmentUserInitializeSpringBootTest {
+    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:9.1")
+            .withDatabaseName("system24dbtest")
+            .withUsername("myuser")
+            .withPassword("secret");
+
+    static {
+        mysqlContainer.start();
+    }
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry propertyRegistry) {
+        propertyRegistry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        propertyRegistry.add("spring.datasource.username", mysqlContainer::getUsername);
+        propertyRegistry.add("spring.datasource.password", mysqlContainer::getPassword);
+        propertyRegistry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    void testInitializeDevelopmentUser() {
+        Optional<User> user = userRepository.findByEmail("Code653ht57t26234yp@example.com");
+
+        assertTrue(user.isPresent());
+        assertEquals("Junior", user.get().getFirst_name());
+        assertEquals("Code653ht57t26234yp", user.get().getLast_name());
+    }
+}

--- a/src/test/java/org/fungover/system2024/user/testUserController.java
+++ b/src/test/java/org/fungover/system2024/user/testUserController.java
@@ -1,0 +1,18 @@
+package org.fungover.system2024.user;
+
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class testUserController {
+    @QueryMapping
+    public String testUserAuth(@AuthenticationPrincipal OAuth2User user) {
+        if (user == null) {
+            throw new AuthenticationCredentialsNotFoundException("User not authenticated");
+        }
+        return user.getAttribute("email");
+    }
+}


### PR DESCRIPTION
**A fake user with a known email is added to database:**
`DevelopmentUserInitialize` 
Test:
`DevelopmentUserInitializeSpringBootTest`

**A custom DevAuthenticationFilter sets the fake users authentication:**
`DevelopmentAuthenticationFilter`
Tests:
`DevelopmentAuthenticationFilterTest`
`DevelopmentAuthenticationFilterSpringBootTest`
And a `testUserController `for a `OAuth2User `to access. 

**A service class is added for cleaner and more readable code:**
`DevelopmentAuthenticationFilterService`
Test:
`DevelopmentAuthenticationFilterServiceTest`

**In the security config:** 
`developmentSecurityFilterChain()` is updated with `.addFilterBefore(developmentAuthenticationFilter, BasicAuthenticationFilter.class)` to apply the filter in `@Profile("development")`. 