### PR TITLE
Add simple routing in frontend #49

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "autoprefixer": "^10.4.20",
         "i18next": "^24.2.0",
         "i18next-browser-languagedetector": "^8.0.2",
+        "i18next-http-backend": "^3.0.1",
         "postcss": "^8.4.49",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2195,6 +2196,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2880,6 +2890,15 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/i18next-http-backend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz",
+      "integrity": "sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "4.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3275,6 +3294,26 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -4259,6 +4298,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -4485,6 +4530,22 @@
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "autoprefixer": "^10.4.20",
     "i18next": "^24.2.0",
     "i18next-browser-languagedetector": "^8.0.2",
+    "i18next-http-backend": "^3.0.1",
     "postcss": "^8.4.49",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
+import { Outlet } from 'react-router-dom';
 import Header from "./components/common/Header";
 import Footer from "./components/common/Footer";
-import LanguageSelector from './components/common/LanguageSelector';
 import { useTranslation} from 'react-i18next';
 import { useTranslationStatus } from './hooks/useTranslationStatus';
 import './i18n';
@@ -8,18 +8,18 @@ import {useEffect, useState} from "react";
 import './index.css'
 
 function App() {
-  const { t, i18n } = useTranslation();
-  const [key, setKey] = useState(0);
-  const { loading, error } = useTranslationStatus();
+    const { i18n } = useTranslation();
+    const [key, setKey] = useState(0);
+    const { loading, error } = useTranslationStatus();
 
-  useEffect(() => {
-    const handleLanguageChange = () => {
-      setKey(prevKey => prevKey + 1);
-    };
-    i18n.on('languageChanged', handleLanguageChange);
-    return () => {
-      i18n.off('languageChanged', handleLanguageChange);
-    };
+    useEffect(() => {
+        const handleLanguageChange = () => {
+            setKey(prevKey => prevKey + 1);
+        };
+        i18n.on('languageChanged', handleLanguageChange);
+        return () => {
+            i18n.off('languageChanged', handleLanguageChange);
+        };
     }, [i18n]);
 
   if (loading) {
@@ -30,24 +30,15 @@ function App() {
     return <p className="text-red-600">{error}</p>; // Show error message
   }
 
-  return (
-    <>
-      <div className="w-full" key={key}>
-        <Header />
-        <main className="w-full">
-          <div className="min-h-screen w-full">
-            <LanguageSelector/>
-
-            <h1 className="my-80 text-center text-4xl"> {t('jollykey')} <strong
-                className="color1">{t('christmaskey')}</strong> {t('andakey')} <strong
-                className="color2">{t('happykey')} </strong>!</h1>
-      </div>
-    </main>
-  <Footer/>
-</div>
-</>
-)
-  ;
+    return (
+        <div className="w-full" key={key}>
+            <Header />
+            <main className="w-full">
+                <Outlet />
+            </main>
+            <Footer/>
+        </div>
+    );
 }
 
 export default App;

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -8,76 +8,76 @@ import { useTranslationStatus } from "../../hooks/useTranslationStatus";
 import i18n from "i18next";
 
 export default function Header() {
-  const [isMobile, setIsMobile] = useState(false);
-  const { t } = useTranslation();
-  const { loading, error } = useTranslationStatus();
+    const [isMobile, setIsMobile] = useState(false);
+    const { t } = useTranslation();
+    const { loading, error } = useTranslationStatus();
 
-  const handleMobileMenu = () => {
-    setIsMobile(!isMobile);
-  };
+    const handleMobileMenu = () => {
+        setIsMobile(!isMobile);
+    };
 
-  useEffect(() => {
-    console.log(t("Home")); // Log to check if translation is correctly loaded
-  }, [i18n.language]);
+    useEffect(() => {
+        console.log(t("Home")); // Log to check if translation is correctly loaded
+    }, [i18n.language]);
 
-  if (loading) {
-    return <p>Loading translations...</p>; // Show loading message
-  }
+    if (loading) {
+        return <p>Loading translations...</p>; // Show loading message
+    }
 
-  if (error) {
-    return <p className="text-red-600">{error}</p>; // Show error message
-  }
+    if (error) {
+        return <p className="text-red-600">{error}</p>; // Show error message
+    }
 
-  const menuItems = [
-    {
-      title: t("homekey"),
-      url: "/",
-    },
-    {
-      title: t("aboutkey"),
-      url: "/",
-    },
-    {
-      title: t("contactkey"),
-      url: "/",
-    },
-  ];
+    const menuItems = [
+        {
+            title: t("homekey"),
+            url: "/",
+        },
+        {
+            title: t("loginkey", "Login"),
+            url: "/login",
+        },
+        {
+            title: t("userskey", "Users"),
+            url: "/users",
+        },
+    ];
 
-  return (
-    <>
-      <header className="w-full bg-white border-b-2 shadow-sm relative z-20 h-16 px-4">
-        <div className="flex justify-between h-full ">
-          <div className="h-full flex items-center">
-            <h1 className="text-2xl font-semibold font-serif">LOGO</h1>
-          </div>
-          <div className="flex flex-row align-center h-full">
-            <div className="hidden md:flex items-center h-full mr-10 gap-4">
-              <LanguageSelector />
-              <MenuItems menuItems={menuItems} />
+    return (
+        <>
+            <header className="w-full bg-white border-b-2 shadow-sm relative z-20 h-16 px-4">
+                <div className="flex justify-between h-full ">
+                    <div className="h-full flex items-center">
+                        <h1 className="text-2xl font-semibold font-serif">LOGO</h1>
+                    </div>
+                    <div className="flex flex-row align-center h-full">
+                        <div className="hidden md:flex items-center h-full mr-10 gap-4">
+                            <LanguageSelector />
+                            <MenuItems menuItems={menuItems} />
+                        </div>
+                        <div className="flex items-center">
+                            <img
+                                src="/bild.png"
+                                alt="Avatar"
+                                className="rounded-full w-10 sm:w-12 md:mr-6"
+                            />
+                            <button onClick={handleMobileMenu} className="md:hidden mx-5">
+                                {" "}
+                                <FaBars size={30} />{" "}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </header>
+            <div
+                className={`${
+                    isMobile
+                        ? "opacity-100 pointer-events-auto translate-y-0 duration-200"
+                        : "opacity-0 pointer-events-none -translate-y-full duration-0"
+                } transition-all ease-out absolute left-0 right-0 z-10 border-2 border-t-0 shadow-sm bg-white p-6 pt-8 rounded-sm md:hidden`}
+            >
+                <MenuItemsMobile menuItemsMobile={menuItems} />
             </div>
-            <div className="flex items-center">
-              <img
-                src="/bild.png"
-                alt="Avatar"
-                className="rounded-full w-10 sm:w-12 md:mr-6"
-              />
-              <button onClick={handleMobileMenu} className="md:hidden mx-5">
-                {" "}
-                <FaBars size={30} />{" "}
-              </button>
-            </div>
-          </div>
-        </div>
-      </header>
-      <div
-        className={`${
-          isMobile
-            ? "opacity-100 pointer-events-auto translate-y-0 duration-200"
-            : "opacity-0 pointer-events-none -translate-y-full duration-0"
-        } transition-all ease-out absolute left-0 right-0 z-10 border-2 border-t-0 shadow-sm bg-white p-6 pt-8 rounded-sm md:hidden`}
-      >
-        <MenuItemsMobile menuItemsMobile={menuItems} />
-      </div>
-    </>
-  );
+        </>
+    );
 }

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from "react";
+import {  useState } from "react";
 import { FaBars } from "react-icons/fa";
 import MenuItems from "./MenuItems";
 import MenuItemsMobile from "./MenuItemsMobile";
 import LanguageSelector from "./LanguageSelector";
 import { useTranslation } from "react-i18next";
 import { useTranslationStatus } from "../../hooks/useTranslationStatus";
-import i18n from "i18next";
 
 export default function Header() {
     const [isMobile, setIsMobile] = useState(false);
@@ -15,10 +14,6 @@ export default function Header() {
     const handleMobileMenu = () => {
         setIsMobile(!isMobile);
     };
-
-    useEffect(() => {
-        console.log(t("Home")); // Log to check if translation is correctly loaded
-    }, [i18n.language]);
 
     if (loading) {
         return <p>Loading translations...</p>; // Show loading message
@@ -50,7 +45,7 @@ export default function Header() {
                     <div className="h-full flex items-center">
                         <h1 className="text-2xl font-semibold font-serif">LOGO</h1>
                     </div>
-                    <div className="flex flex-row align-center h-full">
+                    <div className="flex flex-row items-center h-full">
                         <div className="hidden md:flex items-center h-full mr-10 gap-4">
                             <LanguageSelector />
                             <MenuItems menuItems={menuItems} />

--- a/frontend/src/components/common/MenuItems.tsx
+++ b/frontend/src/components/common/MenuItems.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 type MenuItem = { title: string; url: string };
 
 interface MenuItems {
@@ -5,23 +6,25 @@ interface MenuItems {
 }
 
 export default function MenuItems({ menuItems }: MenuItems) {
-  return (
-    <nav className="h-full w-full font-semibold">
-      <ul className="h-full flex gap-8">
-        {menuItems.map((menu, index) => (
-          <li
-            key={index}
-            className="h-full flex items-center border-b-2 border-white hover:border-purple-800"
-          >
-            <a href={menu.url} className="text-black text-xl">
-              {menu.title}
-            </a>
-          </li>
-        ))}
-        <button className="p-1 w-24 h-2/3 self-center bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700">
-          <p className="text-lg">Login</p>
-        </button>
-      </ul>
-    </nav>
-  );
+    return (
+        <nav className="h-full w-full font-semibold">
+            <ul className="h-full flex gap-8">
+                {menuItems.map((menu, index) => (
+                    <li
+                        key={index}
+                        className="h-full flex items-center border-b-2 border-white hover:border-purple-800"
+                    >
+                        <Link to={menu.url} className="text-black text-xl">
+                            {menu.title}
+                        </Link>
+                    </li>
+                ))}
+                <Link to="/login">
+                    <button className="p-1 w-24 h-2/3 self-center bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700">
+                        <p className="text-lg">Login</p>
+                    </button>
+                </Link>
+            </ul>
+        </nav>
+    );
 }

--- a/frontend/src/components/common/MenuItemsMobile.tsx
+++ b/frontend/src/components/common/MenuItemsMobile.tsx
@@ -1,20 +1,24 @@
+import { Link } from 'react-router-dom';
+
 type MenuItem = { title: string; url: string };
 interface MenuItemsMobile {
-  menuItemsMobile: MenuItem[];
+    menuItemsMobile: MenuItem[];
 }
 
 export default function MenuItemsMobile({ menuItemsMobile }: MenuItemsMobile) {
-  return (
-    <ul className="space-y-6 text-lg font-semibold">
-      {menuItemsMobile.map((menu, index) => (
-        <li key={index}>
-          <a href={menu.url}>{menu.title}</a>
-        </li>
-      ))}
+    return (
+        <ul className="space-y-6 text-lg font-semibold">
+            {menuItemsMobile.map((menu, index) => (
+                <li key={index}>
+                    <Link to={menu.url}>{menu.title}</Link>
+                </li>
+            ))}
 
-      <button className="p-1 w-full  bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700 ">
-        Sign in
-      </button>
-    </ul>
-  );
+            <Link to="/login" className="block">
+                <button className="p-1 w-full bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700">
+                    Sign in
+                </button>
+            </Link>
+        </ul>
+    );
 }

--- a/frontend/src/components/common/MenuItemsMobile.tsx
+++ b/frontend/src/components/common/MenuItemsMobile.tsx
@@ -8,17 +8,20 @@ interface MenuItemsMobile {
 export default function MenuItemsMobile({ menuItemsMobile }: MenuItemsMobile) {
     return (
         <ul className="space-y-6 text-lg font-semibold">
-            {menuItemsMobile.map((menu, index) => (
-                <li key={index}>
+            {menuItemsMobile.map((menu) => (
+                <li key={menu.url}>
                     <Link to={menu.url}>{menu.title}</Link>
                 </li>
             ))}
 
-            <Link to="/login" className="block">
-                <button className="p-1 w-full bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700">
+            <li>
+                <Link
+                    to="/login"
+                    className="p-1 w-full inline-flex items-center justify-center bg-blue-600 text-white rounded-md shadow-md hover:bg-blue-700"
+                >
                     Sign in
-                </button>
-            </Link>
+                </Link>
+            </li>
         </ul>
     );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@ import HomePage from './pages/HomePage.tsx'
 import UsersPage from "./pages/UsersPage.tsx";
 import App from './App.tsx'
 import LoginPage from "./pages/LoginPage.tsx";
-import {createBrowserRouter, RouterProvider,} from 'react-router-dom';
+import {createBrowserRouter, redirect, RouterProvider,} from 'react-router-dom';
 import './i18n';
 
 const router = createBrowserRouter([
@@ -24,6 +24,14 @@ const router = createBrowserRouter([
             {
                 path: 'users',
                 element: <UsersPage />
+            },
+            {
+                path: 'auth/login',
+                loader: () => redirect('/login'),
+            },
+            {
+                path: '*',
+                element: <div>Not found</div>
             }
         ]
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
 import './index.css'
+import HomePage from './pages/HomePage.tsx'
 import UsersPage from "./pages/UsersPage.tsx";
 import App from './App.tsx'
 import LoginPage from "./pages/LoginPage.tsx";
@@ -11,18 +12,20 @@ const router = createBrowserRouter([
     {
         path: '/',
         element: <App />,
-    },
-    {
-        path: '/cake',
-        element: <div style={{ fontSize: 150 }}>🍰</div>,
-    },
-    {
-        path:'/users',
-        element: <UsersPage/>,
-    },
-    {
-        path: '/auth/login',
-        element: <LoginPage/>
+        children: [
+            {
+                index: true,
+                element: <HomePage />
+            },
+            {
+                path: 'login',
+                element: <LoginPage />
+            },
+            {
+                path: 'users',
+                element: <UsersPage />
+            }
+        ]
     }
 ]);
 
@@ -31,5 +34,3 @@ createRoot(document.getElementById('root')!).render(
         <RouterProvider router={router} />
     </StrictMode>
 );
-
-

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,18 @@
+import LanguageSelector from '../components/common/LanguageSelector';
+import { useTranslation } from 'react-i18next';
+
+function HomePage() {
+    const { t } = useTranslation();
+
+    return (
+        <div className="min-h-screen w-full">
+            <LanguageSelector/>
+            <h1 className="my-80 text-center text-4xl">
+                {t('jollykey')} <strong className="color1">{t('christmaskey')}</strong>
+                {t('andakey')} <strong className="color2">{t('happykey')} </strong>!
+            </h1>
+        </div>
+    );
+}
+
+export default HomePage;


### PR DESCRIPTION
### This PR implements simple routing for frontend navigation.

- Home, Login, and Users pages now accessible via routing
- Navigation links in Header (desktop and mobile)
- Shared Header/Footer layout across all routes

Tested locally, all pages working as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Added a localized Home page with language selector and nested routes for Home, Login, and Users.
* Refactor
  - App now renders content via client-side nested routing with a persistent header and footer; new route structure and Not Found handling.
* Style
  - Header menu updated to Home, Login, and Users; menu navigation now uses client-side links.
* Chores
  - Added an HTTP backend for i18n translation loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->